### PR TITLE
Upkeep/code review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,18 @@ REBAR=./rebar3
 
 all: compile
 
+clean:
+	@$(REBAR) clean -a
+
 compile:
 	@$(REBAR) compile
 
 dialyzer:
 	@$(REBAR) dialyzer
 
-clean:
-	@$(REBAR) clean -a
+eunit:
+	@$(REBAR) do eunit
+
+test: eunit dialyzer
 
 .PHONY: all deps compile clean

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 Minimal file and directory watching in Erlang using inotify
 
-This is an application built around an Erlang port driver that interacts with
-inotify.
-
 ## Building
 
 ```
@@ -11,33 +8,22 @@ rebar3 compile
 
 ## Usage
 
-### `erl-filewatch:start(Self, Paths) -> {ok, Handle} | {error, _}`
+### `filewatch:start(Pid, Pairs = [{File, Term} ...]) -> {ok, Handle} | {error, _}`
+This is an application built around an Erlang port driver that interacts with
+inotify. You feed it a list of `{File, Term}` pairs, and when inotify detects
+events occurring at `File`, filewatch sends `Term` to `Pid`.
 
-Starts watching files/directories in `Paths`. Events that occur are batched until
-`CooldownMs` seconds have elapsed without events, or until 12 messages are
-collected.
-
-`Paths` is comprised of `{"path/to/file", Term}` or `{"path/to/dir/*", Term}`
-pairs. An inotify watch descriptor is opened on each unique directory in
-`Paths`, and a mapping of `{Descriptor, Filename}` to `Term` is created. When a
-particular watch is triggered, a `{Descriptor, Filename}` pair is sent from the
-port driver to Erlang, and is used as a key to find the correct `Term` to send
-to `Self`, if any.
-
-## FAQ
-
-### Why not open watch descriptors on individual files?
-
-The specific intended use case for this library is to trigger a response when a
-particular file is replaced. If an inotify watch descriptor is open on a file
-that gets replaced, no further events can be read from that descriptor. One
-option is to reopen a watch descriptor whenever a file is replaced, but watching
-directories and filtering in Erlang seems simpler.
+## How it works
+An inotify watch descriptor is opened for every unique directory in
+`Pairs`. When events for a particular watch descriptor are received from the
+Port Driver, they are filtered to only include the files specified in
+`Paths`. Watch descriptors are opened on directories rather than individual
+files to prevent having to reopen watch descriptors for files that get replaced.
 
 ## TODO
 
 - Add cooldown timeout in Erlang
 
-- Add tests
+- Add (more) tests
 
 - Add target for afl-fuzz

--- a/c_src/build.sh
+++ b/c_src/build.sh
@@ -1,8 +1,4 @@
 #!/usr/bin/env sh
-#
-# Evaluate which function is fastest on this machine right now, and
-# build it into a shared object.  This is just a shell script rather
-# than a Makefile since there's not much point avoiding rebuilds here.
 
 set -eu
 
@@ -16,7 +12,7 @@ ERL_LIB_DIR=${ERL_LIB_DIR:-${ERL_ROOT}/usr/lib}
 ERTS_INCLUDE_DIR=${ERTS_INCLUDE_DIR:-${ERL_ROOT}/erts-$(erlang_eval 'erlang:system_info(version)')/include}
 
 CC=${CC:-cc}
-DEFAULT_CFLAGS="-O3 -march=native -mtune=native -ggdb -Wall -Wextra -Wno-missing-field-initializers"
+DEFAULT_CFLAGS="-O3 -march=native -mtune=native -ggdb -Wall -Wextra"
 CFLAGS="-fPIC -I${ERTS_INCLUDE_DIR} -I${ERL_INCLUDE_DIR} -std=gnu11 ${CFLAGS:-$DEFAULT_CFLAGS}"
 LDFLAGS="-L${ERL_LIB_DIR} -lei ${LDFLAGS:-}"
 

--- a/c_src/filewatch_inotify.c
+++ b/c_src/filewatch_inotify.c
@@ -11,7 +11,7 @@
 
 #include "macrology.h"
 
-enum { MAX_COOLDOWNS = 12, MSG_LENGTH = 11 };
+enum { MAX_COOLDOWNS = 12, MSG_LENGTH = 11, CALL_ARG = 1 };
 
 /*
   A struct inotify_event's relevant data is copied to an array of
@@ -88,11 +88,13 @@ static void stop(ErlDrvData self_)
 
 static ErlDrvSSizeT call(
     ErlDrvData self_,
-    unsigned int UNUSED,
+    unsigned int operation,
     char *buf, ErlDrvSizeT UNUSED,
     char **rbuf, ErlDrvSizeT rlen,
     unsigned int *UNUSED)
 {
+    if (operation == CALL_ARG) goto fail_op_arg;
+
     struct instance *self = (struct instance *)self_;
 
     int index = 0;
@@ -149,6 +151,7 @@ static ErlDrvSSizeT call(
 
   fail_alloc:
   fail_decode:
+  fail_op_arg:
     return -1;
 }
 

--- a/c_src/macrology.h
+++ b/c_src/macrology.h
@@ -1,3 +1,11 @@
+/* o/~ readings in macrology /
+ *     never meant that much to me /
+ *     the language I thought was just so /
+ *     she tells me, we ain't compatible
+ *
+ * Copyright 2015 AdGear Technologies Inc.
+ */
+
 #pragma once
 
 #define CONCAT_HELPER(x,y) x##y

--- a/src/filewatch.app.src
+++ b/src/filewatch.app.src
@@ -1,5 +1,16 @@
 {application, filewatch,
  [{description, "Watch for file changes"},
-  {vsn, git}
- ]
-}.
+  {vsn, "0.1"},
+  {registered, []},
+  {mod, {filewatch, []}},
+  {applications,
+   [kernel,
+    stdlib
+   ]},
+  {env,[]},
+  {modules, []},
+
+  {maintainers, []},
+  {licenses, []},
+  {links, []}
+ ]}.


### PR DESCRIPTION
This branch focuses on the code review performed on 2017-02-08.

Some of the larger tasks, such as implementing deduplication in C, switching to a trie-like structure for `watch_map`, and using refs instead of atoms for mailbox scanning, are left for the future.

There are a few tasks remaining for this branch:
- [x] Document `create_watch_map`
- [x] Call `load/0` only when starting the application
- [x] Add check for priv directory