### PR TITLE
Eliminate dublicate inotify events

### DIFF
--- a/c_src/build.sh
+++ b/c_src/build.sh
@@ -18,13 +18,16 @@ LDFLAGS="-L${ERL_LIB_DIR} -lei ${LDFLAGS:-}"
 
 OS="$(uname -s)"
 
+SRC=./c_src
 case "$OS" in
     Linux)
         IMPLEMENTATION=filewatch_inotify
+        SRCFILES="$SRC/$IMPLEMENTATION.c $SRC/notif_set_tlh_htable.c $SRC/optics_htable/htable.c"
         ;;
     Darwin)
         LDFLAGS="$LDFLAGS -flat_namespace -undefined suppress"
         IMPLEMENTATION=filewatch_noop
+        SRCFILES="$SRC/$IMPLEMENTATION.c"
         ;;
     *)
         IMPLEMENTATION=filewatch_noop
@@ -36,7 +39,6 @@ if [ "$IMPLEMENTATION" = "filewatch_noop" ]; then
 fi
 
 TARGET=${TARGET:-./priv/filewatch.so}
-SRC=./c_src
 
 mkdir -p priv
 
@@ -50,4 +52,4 @@ up_to_date_p() {
 
 if (up_to_date_p); then exit 0; fi
 
-exec "$CC" $CFLAGS -shared -o "$TARGET" $SRC/$IMPLEMENTATION.c $LDFLAGS
+exec "$CC" $CFLAGS -shared -o "$TARGET" $SRCFILES $LDFLAGS

--- a/c_src/notif_set.h
+++ b/c_src/notif_set.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#define CHECK_SUCCESS(RET_VAL) do { if(!(RET_VAL)) goto fn_fail; } while(0)
+
+/* forward declarations */
+struct Notif_set;
+struct Notif_set_itr;
+struct Message {
+    uint64_t wd;
+    size_t len;
+    char *name;
+};
+
+struct Notif_set *notif_set_new();
+void notif_set_destroy(struct Notif_set *tab);
+bool notif_set_insert(struct Notif_set *tab, const struct Message *msg, int *err_flag);
+bool notif_set_del(struct Notif_set *tab, const struct Message *msg, int *err_flag);
+bool notif_set_find(const struct Notif_set *tab, const struct Message *msg, int *err_flag);
+void notif_set_print(const struct Notif_set *tab);
+void notif_set_fprint(FILE *fp, const struct Notif_set *tab);
+struct Notif_set_itr *notif_set_itr_init(struct Notif_set *tab);
+void notif_set_itr_destroy(struct Notif_set_itr *itr);
+bool notif_set_itr_next(struct Notif_set_itr *itr, struct Message *msg);
+bool notif_set_itr_remove(const struct Notif_set_itr *itr);
+size_t notif_set_get_length(const struct Notif_set *tab);

--- a/c_src/notif_set_tlh_htable.c
+++ b/c_src/notif_set_tlh_htable.c
@@ -1,0 +1,245 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <limits.h>
+#include "notif_set.h"
+#include "optics_htable/htable.h"
+
+struct Notif_set {
+    // a two-level hash table where the value of each
+    // key points to another (level2) hash table
+    struct htable lev1; // directory watch descriptors
+    size_t len;
+};
+
+struct Notif_set_itr {
+    struct Notif_set *tab;
+    struct htable_bucket *itr1, *itr2;
+};
+
+struct Notif_set *notif_set_new()
+{
+    struct Notif_set *tlh = calloc(1, sizeof(*tlh));
+    CHECK_SUCCESS(tlh);
+    htable_init(&tlh->lev1);
+    tlh->len = 0;
+    return tlh;
+
+fn_fail:
+    return NULL;
+}
+
+void notif_set_destroy(struct Notif_set *tab)
+{
+    struct htable_bucket *itr;
+    // destroy each level2 table
+    for(itr = htable_next(&tab->lev1, NULL); itr; itr = htable_next(&tab->lev1, itr)) {
+        htable_reset((struct htable*) itr->value);
+        free((struct htable*) itr->value);
+    }
+    htable_reset(&tab->lev1);
+    free(tab);
+}
+
+bool notif_set_insert(struct Notif_set *tab, const struct Message *msg, int *err_flag)
+{
+    // IMPORTANT: Each htable owns its keys, but the
+    //            values are owned by the user.
+    *err_flag = 0;
+    struct Key *key_int = NULL;
+    struct Key *key_str = NULL;
+    bool new_key_int_added = false;
+
+    key_int = htable_key_int(msg->wd);
+    CHECK_SUCCESS(key_int);
+    struct htable_ret get_ret = htable_get(&tab->lev1, key_int);
+    struct htable *lev2_tab = (struct htable*) get_ret.value;
+    if(!get_ret.ok) {
+        // We have a new directory wd; insert to level1
+        // First create a level2 table for this wd (the value)
+        lev2_tab = calloc(1, sizeof(*lev2_tab));
+        CHECK_SUCCESS(lev2_tab);
+        htable_init(lev2_tab);
+        CHECK_SUCCESS(!htable_put(&tab->lev1, key_int, (uint64_t) lev2_tab).err_flag);
+        new_key_int_added = true; //necessary for propser cleanup on error
+    }
+    else {
+        htable_key_free(key_int); //because did not put it in the htable
+    }
+
+    // add the filename to the level2 hash table of this wd
+    key_str = htable_key_str(msg->name);
+    CHECK_SUCCESS(key_str);
+    struct htable_ret put_ret = htable_put(lev2_tab, key_str, 0);
+    CHECK_SUCCESS(!put_ret.err_flag);
+    if(!put_ret.ok) { //filename is already in the set
+        htable_key_free(key_str); //because did not put it in the htable
+        return false;
+    }
+
+    tab->len++;
+    return true;
+
+fn_fail:
+    if(new_key_int_added) {
+        htable_del(&tab->lev1, key_int);
+    }
+    else {
+        htable_key_free(key_int);
+    }
+    htable_key_free(key_str);
+    *err_flag = 1;
+    return false;
+}
+
+bool notif_set_find(const struct Notif_set *tab, const struct Message *msg, int *err_flag)
+{
+    *err_flag = 0;
+    struct Key *key = htable_key_int(msg->wd);
+    CHECK_SUCCESS(key);
+    struct htable_ret get_ret = htable_get(&tab->lev1, key);
+    htable_key_free(key);
+    if(!get_ret.ok) {
+        return false;
+    }
+    key = htable_key_str(msg->name);
+    CHECK_SUCCESS(key);
+    get_ret = htable_get((struct htable*) get_ret.value, key);
+    htable_key_free(key);
+    if(!get_ret.ok) {
+        return false;
+    }
+
+    return true;
+
+fn_fail:
+    *err_flag = 1;
+    return false;
+}
+
+struct Notif_set_itr *notif_set_itr_init(struct Notif_set *tab)
+{
+    struct Notif_set_itr *itr = calloc(1, sizeof(*itr));
+    CHECK_SUCCESS(itr);
+    if(tab != NULL) {
+        itr->tab = tab;
+        itr->itr1 = htable_next(&tab->lev1, NULL);
+    }
+
+    return itr;
+
+fn_fail:
+    return NULL;
+}
+
+void notif_set_itr_destroy(struct Notif_set_itr *itr)
+{
+    free(itr);
+}
+
+bool notif_set_itr_next(struct Notif_set_itr *itr, struct Message *msg)
+{
+    if(itr->itr1 == NULL) {
+        return false;
+    }
+    // Advance the second-level iterator first
+    if((itr->itr2 = htable_next((struct htable *) itr->itr1->value, itr->itr2))) {
+        assert(itr->itr1->key->n == sizeof(uint64_t));
+        msg->wd = *((uint64_t*) itr->itr1->key->bytes); //Really don't like this
+        memcpy(msg->name, itr->itr2->key->bytes, itr->itr2->key->n);
+        return true;
+    }
+    // If second level is exhausted, advance the iterator in the first level
+    if((itr->itr1 = htable_next(&itr->tab->lev1, itr->itr1))) {
+        // Call recursively to iterate in the second level
+        return notif_set_itr_next(itr, msg);
+    }
+
+    return false;
+}
+
+bool notif_set_itr_remove(const struct Notif_set_itr *itr)
+{
+    // First, attempt to remove from the second-level table
+    if(itr->itr2) {
+        if(htable_key_free((struct Key*) itr->itr2->key)) {
+            itr->itr2->key = NULL;
+            ((struct htable*)(itr->itr1->value))->len--;
+            // We could destroy the level2 htable and remove
+            // the corresponding entry in the level1 table if
+            // the level2 table becomes empty. But, let's do it
+            // in a lazy fashion and leave it to the destroy function.
+            itr->tab->len--;
+            return true;
+        }
+    }
+
+    // If itr2 is NULL, then itr1 must be NULL too, otherwise
+    // we have some kind of a dangling iterator. Of course, I'm
+    // assuming that the iterator is only progressed by _next function.
+    assert(itr->itr1 == NULL);
+    return false;
+}
+
+void notif_set_fprint(FILE *fp, const struct Notif_set *tab)
+{
+    struct htable_bucket *itr1, *itr2;
+    int entry_idx = 0;
+
+    for(itr1 = htable_next(&tab->lev1, NULL);
+        itr1;
+        itr1 = htable_next(&tab->lev1, itr1)) {
+        for(itr2 = htable_next((struct htable*) itr1->value, NULL);
+            itr2;
+            itr2 = htable_next((struct htable*) itr1->value, itr2)) {
+            fprintf(fp, "Entry %d: WD = %d, name = %s\n", entry_idx,
+                    *((int*) itr1->key->bytes),
+                    itr2->key->bytes); //no cast; bytes is char[]
+            entry_idx++;
+        }
+    }
+
+    if(entry_idx == 0) {
+        fprintf(fp, "Table empty!\n");
+    }
+}
+
+void notif_set_print(const struct Notif_set *tab)
+{
+    return notif_set_fprint(stdout, tab);
+}
+
+size_t notif_set_get_length(const struct Notif_set *tab)
+{
+    return tab->len;
+}
+
+bool notif_set_del(struct Notif_set *tab, const struct Message *msg, int *err_flag)
+{
+    *err_flag = 0;
+    struct Key *key = htable_key_int(msg->wd);
+    CHECK_SUCCESS(key);
+    struct htable_ret get_ret = htable_get(&tab->lev1, key);
+    htable_key_free(key);
+    if(!get_ret.ok) {
+        return false;
+    }
+    key = htable_key_str(msg->name);
+    CHECK_SUCCESS(key);
+    if(htable_del((struct htable*) get_ret.value, key).ok) {
+        tab->len--;
+        // We could destroy the level2 htable and remove
+        // the corresponding entry in the level1 table if
+        // the level2 table becomes empty. But, let's do it
+        // in a lazy fashion and leave it to the destroy function.
+        htable_key_free(key);
+        return true;
+    }
+
+    htable_key_free(key);
+    return false;
+
+fn_fail:
+    *err_flag = 1;
+    return false;
+}

--- a/c_src/optics_htable/LICENSE
+++ b/c_src/optics_htable/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2016, Rémi Attab
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/c_src/optics_htable/htable.c
+++ b/c_src/optics_htable/htable.c
@@ -1,0 +1,252 @@
+/* htable.c
+   Rémi Attab (remi.attab@gmail.com), 10 Mar 2016
+   FreeBSD-style copyright and disclaimer apply
+
+   Modified for use in erl_filewatch by Seyed Mirsadeghi
+   (hessam.mirsadeghi@gmail.com), 5 Sep. 2017
+*/
+
+#include <stdlib.h>
+#include <assert.h>
+#include <limits.h>
+#include "htable.h"
+
+extern inline uint64_t htable_hash(const struct Key *key);
+
+// -----------------------------------------------------------------------------
+// hash
+// -----------------------------------------------------------------------------
+
+// FNV-1a hash implementation: http://isthe.com/chongo/tech/comp/fnv/
+inline uint64_t htable_hash(const struct Key *key)
+{
+    uint64_t hash = 0xcbf29ce484222325;
+    for (size_t i = 0; i < key->n; ++i)
+        hash = (hash ^ key->bytes[i]) * 0x100000001b3;
+
+    return hash;
+}
+
+
+// -----------------------------------------------------------------------------
+// config
+// -----------------------------------------------------------------------------
+
+enum { probe_window = 8 };
+
+
+// -----------------------------------------------------------------------------
+// basics
+// -----------------------------------------------------------------------------
+
+void htable_reset(struct htable *ht)
+{
+    if (ht->table) {
+        for (size_t i = 0; i < ht->cap; ++i) {
+            if (ht->table[i].key) free((struct Key *) ht->table[i].key);
+        }
+        free(ht->table);
+    }
+    *ht = (struct htable) {0};
+}
+
+static bool table_put(
+        struct htable_bucket *table, size_t cap,
+        const struct Key *key, uint64_t value)
+{
+    uint64_t hash = htable_hash(key);
+
+    for (size_t i = 0; i < probe_window; ++i) {
+        struct htable_bucket *bucket = &table[(hash + i) % cap];
+        if (bucket->key) continue;
+
+        bucket->key = key;
+        bucket->value = value;
+        return true;
+    }
+
+    return false;
+}
+
+static bool htable_resize(struct htable *ht, size_t cap)
+{
+    if (cap <= ht->cap) return true;
+
+    size_t new_cap = ht->cap ? ht->cap : 1;
+    while (new_cap < cap) new_cap *= 2;
+
+    struct htable_bucket *new_table = calloc(new_cap, sizeof(*new_table));
+    if(new_table == NULL) {
+        return false;
+    }
+
+    for (size_t i = 0; i < ht->cap; ++i) {
+        struct htable_bucket *bucket = &ht->table[i];
+        if (!bucket->key) continue;
+
+        if (!table_put(new_table, new_cap, bucket->key, bucket->value)) {
+            free(new_table);
+            return htable_resize(ht, new_cap * 2);
+        }
+    }
+
+    free(ht->table);
+    ht->cap = new_cap;
+    ht->table = new_table;
+    return true;
+}
+
+bool htable_reserve(struct htable *ht, size_t items)
+{
+    return htable_resize(ht, items * 4);
+}
+
+struct Key *htable_key_int(uint64_t i)
+{
+    struct Key *key = malloc(sizeof(*key) + sizeof(i));
+    if(key == NULL) {
+        return NULL;
+    }
+    key->n = sizeof(i);
+    memcpy(key->bytes, &i, sizeof(i));
+    return key;
+}
+
+struct Key *htable_key_str(const char *str)
+{
+    size_t len = strnlen(str, NAME_MAX);
+    if(len < NAME_MAX) {
+        len++; // to count for the null character
+    }
+    struct Key *key = malloc(sizeof(*key) + len);
+    if(key == NULL) {
+        return NULL;
+    }
+    key->n = len;
+    memcpy(key->bytes, str, len);
+    return key;
+}
+
+bool htable_key_free(struct Key *key)
+{
+    if(key == NULL) {
+        return false;
+    }
+
+    free(key);
+    return true;
+}
+
+
+// -----------------------------------------------------------------------------
+// ops
+// -----------------------------------------------------------------------------
+
+struct htable_ret htable_get(const struct htable *ht, const struct Key *key)
+{
+    if(ht->len == 0) {
+        return (struct htable_ret) { .ok = false };
+    }
+
+    uint64_t hash = htable_hash(key);
+
+    for (size_t i = 0; i < probe_window; ++i) {
+        struct htable_bucket *bucket = &ht->table[(hash + i) % ht->cap];
+
+        if (!bucket->key) continue;
+        if (bucket->key->n != key->n) continue;
+        if (memcmp(bucket->key->bytes, key->bytes, key->n) != 0) continue;
+
+        return (struct htable_ret) { .ok = true, .value = bucket->value };
+    }
+
+    return (struct htable_ret) { .ok = false };
+}
+
+struct htable_ret htable_put(struct htable *ht, const struct Key *key, uint64_t value)
+{
+    uint64_t hash = htable_hash(key);
+    if(!htable_resize(ht, probe_window)) {
+        return (struct htable_ret) { .ok = false, .err_flag = 1 };
+    }
+
+    struct htable_bucket *empty = NULL;
+
+    for (size_t i = 0; i < probe_window; ++i) {
+        struct htable_bucket *bucket = &ht->table[(hash + i) % ht->cap];
+
+        if (bucket->key) {
+            if (bucket->key->n != key->n) continue;
+            if (memcmp(bucket->key->bytes, key->bytes, key->n) != 0 ) continue;
+            return (struct htable_ret) { .ok = false,
+                                         .value = bucket->value,
+                                         .err_flag = 0
+                                       };
+        }
+
+        if (!empty) empty = bucket;
+    }
+
+    if (empty) {
+        ht->len++;
+        empty->key = key;
+        empty->value = value;
+        return (struct htable_ret) { .ok = true, .err_flag = 0 };
+    }
+
+    if(!htable_resize(ht, ht->cap * 2)) {
+        return (struct htable_ret) { .ok = false, .err_flag = 1 };
+    }
+    return htable_put(ht, key, value);
+}
+
+struct htable_ret htable_del(struct htable *ht, const struct Key *key)
+{
+    if(ht->len == 0) {
+        return (struct htable_ret) { .ok = false };
+    }
+
+    uint64_t hash = htable_hash(key);
+
+    for (size_t i = 0; i < probe_window; ++i) {
+        struct htable_bucket *bucket = &ht->table[(hash + i) % ht->cap];
+
+        if (!bucket->key) continue;
+        if (bucket->key->n != key->n) continue;
+        if (memcmp(bucket->key->bytes, key->bytes, key->n) != 0) continue;
+
+        ht->len--;
+        free((struct Key *) bucket->key);
+        bucket->key = NULL;
+        return (struct htable_ret) { .ok = true, .value = bucket->value };
+    }
+
+    return (struct htable_ret) { .ok = false };
+}
+
+
+struct htable_bucket * htable_next(
+        const struct htable *ht, struct htable_bucket *bucket)
+{
+    if (!ht->table) return NULL;
+
+    size_t i = 0;
+    if (bucket) i = (bucket - ht->table) + 1;
+
+    for (; i < ht->cap; ++i) {
+        bucket = &ht->table[i];
+        if (bucket->key) return bucket;
+    }
+
+    return NULL;
+}
+
+size_t htable_size(const struct htable *ht)
+{
+    return ht->len;
+}
+
+void htable_init(struct htable *ht)
+{
+    *ht = (struct htable) { 0 };
+}

--- a/c_src/optics_htable/htable.h
+++ b/c_src/optics_htable/htable.h
@@ -1,0 +1,73 @@
+/* htable.h
+   Rémi Attab (remi.attab@gmail.com), 10 Mar 2016
+   FreeBSD-style copyright and disclaimer apply
+
+   Modified for use in erl_filewatch by Seyed Mirsadeghi
+   (hessam.mirsadeghi@gmail.com), 5 Sep. 2017
+*/
+
+#pragma once
+
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+// -----------------------------------------------------------------------------
+// struct
+// -----------------------------------------------------------------------------
+
+struct Key
+{
+    size_t n;
+    char bytes[];
+};
+
+struct htable_bucket
+{
+    const struct Key *key;
+    uint64_t value;
+};
+
+struct htable
+{
+    size_t len;
+    size_t cap;
+    struct htable_bucket *table;
+};
+
+
+struct htable_ret
+{
+    bool ok;
+    uint64_t value;
+    bool err_flag;
+};
+
+struct htable_itr
+{
+    struct htable *ht;
+    struct htable_bucket *bucket;
+    bool is_valid;
+};
+
+// -----------------------------------------------------------------------------
+// basics
+// -----------------------------------------------------------------------------
+
+void htable_reset(struct htable *);
+bool htable_reserve(struct htable *, size_t items);
+struct Key *htable_key_int(uint64_t i);
+struct Key *htable_key_str(const char *str);
+bool htable_key_free(struct Key *key);
+
+
+// -----------------------------------------------------------------------------
+// ops
+// -----------------------------------------------------------------------------
+
+struct htable_ret htable_get(const struct htable *, const struct Key *key);
+struct htable_ret htable_put(struct htable *, const struct Key *key, uint64_t value);
+struct htable_ret htable_del(struct htable *, const struct Key *key);
+struct htable_bucket * htable_next(const struct htable *, struct htable_bucket *bucket);
+size_t htable_size(const struct htable *ht);
+void htable_init(struct htable *ht);

--- a/src/filewatch.erl
+++ b/src/filewatch.erl
@@ -90,12 +90,13 @@ create_watch_map([{Path, Term} | Rest], Port, Map) ->
 
 
 add_to_watch_map(Dir, File, Term, Port, Map) ->
-    {ok, WatchDescriptor} =
+    {WatchDescriptor, NewMap} =
         case maps:find(Dir, Map) of
-            error -> add_watch(Dir, Port);
-            Match -> Match
+            error -> {ok, WD} = add_watch(Dir, Port),
+                     {WD, maps:put(Dir, WD, Map)};
+            {ok, WD} -> {WD, Map}
         end,
-    maps:put({WatchDescriptor, File}, Term, Map).
+    maps:put({WatchDescriptor, File}, Term, NewMap).
 
 
 add_watch(Dir, Port) ->
@@ -106,7 +107,7 @@ add_watch(Dir, Port) ->
 watch(S = #state{port = Port}) ->
     receive
         {Port, Msgs} ->
-            handle_events(S, ordsets:from_list(Msgs)),
+            handle_events(S, Msgs),
             watch(S);
         terminate ->
             ok;


### PR DESCRIPTION
This PR is meant to avoid sending duplicate inotify events from filewatch to the parent process. To this end, we push each event into an abstract table that discards an event if it is already in the table. Having processed a certain number of events, we iterate the abstract table to send out each entry.

The abstract table is currently implemented as a two-level hash table (in TLH_absTab.c). In the first level, we keep track of directory watch descriptors, whereas in the second level, we keep track of filenames in each specific directory. So, in the first level, we have the directory watch descriptor as the key and a (second level) hash table as the value. In the second level, we have the filename as the key and do not have any value.

Currently, glib is used to provide the implementation for each individual hash table.