### PR TITLE
Fix include directory

### DIFF
--- a/c_src/build.sh
+++ b/c_src/build.sh
@@ -3,7 +3,7 @@
 set -eu
 
 erlang_eval() {
-    erl -noshell -s init stop -eval "io:format(\"~s\", [$1]), halt()."
+    erl -noshell -eval "io:format(\"~s\", [$1]), halt()." -s init stop
 }
 
 ERL_ROOT=${ERL_ROOT:-$(erlang_eval 'code:root_dir()')}


### PR DESCRIPTION
On OTP 26.0.2, the emulator calls fail with the following:

```sh
root@787c3fa7af3a:/app# erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])."
Error! Failed to eval: io:format("~s/erts-~s/include/", [code:root_dir(), erlang:system_info(version)]).
```

Changing it to the version in the PR solves the issue:

```sh
root@787c3fa7af3a:/app# erl -noshell -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)])." -s init stop; echo
/usr/local/lib/erlang/erts-14.0.2/include/
```